### PR TITLE
ZW099 update (re-add needed)

### DIFF
--- a/app.json
+++ b/app.json
@@ -1619,8 +1619,7 @@
                     }
                 },
                 "associationGroups": [
-                    1,
-                    2
+                    1
                 ],
                 "defaultConfiguration": [
                     {
@@ -1642,6 +1641,11 @@
                         "id": 91,
                         "size": 2,
                         "value": 3
+                    },
+                    {
+                        "id": 101,
+                        "size": 1,
+                        "value": 12
                     },
                     {
                         "id": 111,
@@ -1778,18 +1782,25 @@
                     }
                 },
                 {
-                    "id": 103,
+                    "id": 102,
                     "type": "dropdown",
                     "label": {
-                        "en": "Information reports send to association group 3",
-                        "nl": "Informatie updates naar associatie groep 3"
+                        "en": "Information reports send to association group 2",
+                        "nl": "Informatie updates naar associatie groep 2"
                     },
                     "hint": {
-                        "en": "Which information needs to be send to devices in association group 3",
-                        "nl": "Welke informatie moet naar apparaten in associatie groep 3 worden gestuurd"
+                        "en": "Which information needs to be send to devices in association group 2",
+                        "nl": "Welke informatie moet naar apparaten in associatie groep 2 worden gestuurd"
                     },
-                    "value": "4",
+                    "value": "8",
                     "values": [
+                        {
+                            "id": "0",
+                            "label": {
+                                "en": "Nothing",
+                                "nl": "Geen"
+                            }
+                        },
                         {
                             "id": "1",
                             "label": {
@@ -1817,6 +1828,84 @@
                                 "en": "Energy (kWh)",
                                 "nl": "Energie (kWh)"
                             }
+                        },
+                        {
+                            "id": "12",
+                            "label": {
+                                "en": "Power (Watt) & Energy (kWh)",
+                                "nl": "Vermogen (Watt) & Energie (kWh)"
+                            }
+                        },
+                        {
+                            "id": "15",
+                            "label": {
+                                "en": "Everything",
+                                "nl": "Alles"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": 103,
+                    "type": "dropdown",
+                    "label": {
+                        "en": "Information reports send to association group 3",
+                        "nl": "Informatie updates naar associatie groep 3"
+                    },
+                    "hint": {
+                        "en": "Which information needs to be send to devices in association group 3",
+                        "nl": "Welke informatie moet naar apparaten in associatie groep 3 worden gestuurd"
+                    },
+                    "value": "0",
+                    "values": [
+                        {
+                            "id": "0",
+                            "label": {
+                                "en": "Nothing",
+                                "nl": "Geen"
+                            }
+                        },
+                        {
+                            "id": "1",
+                            "label": {
+                                "en": "Voltage (V)",
+                                "nl": "Voltage (V)"
+                            }
+                        },
+                        {
+                            "id": "2",
+                            "label": {
+                                "en": "Current (A)",
+                                "nl": "Current (A)"
+                            }
+                        },
+                        {
+                            "id": "4",
+                            "label": {
+                                "en": "Power (Watt)",
+                                "nl": "Vermogen (Watt)"
+                            }
+                        },
+                        {
+                            "id": "8",
+                            "label": {
+                                "en": "Energy (kWh)",
+                                "nl": "Energie (kWh)"
+                            }
+                        },
+                        {
+                            "id": "12",
+                            "label": {
+                                "en": "Power (Watt) & Energy (kWh)",
+                                "nl": "Vermogen (Watt) & Energie (kWh)"
+                            }
+                        },
+                        {
+                            "id": "15",
+                            "label": {
+                                "en": "Everything",
+                                "nl": "Alles"
+                            }
                         }
                     ]
                 },
@@ -1828,8 +1917,8 @@
                         "nl": "Informatie update interval associatie groep 1"
                     },
                     "hint": {
-                        "en": "This parameter indicates how often the Smart Dimmer should send an update Wattage",
-                        "nl": "Deze parameter geeft aan hoe vaak de Smart Dimmer een update met Wattage stuurt"
+                        "en": "This parameter indicates how often the Smart Dimmer should send an update with new information to Homey",
+                        "nl": "Deze parameter geeft aan hoe vaak de Smart Dimmer een update met nieuwe informatie naar Homey"
                     },
                     "attr": {
                         "min": 1,
@@ -1845,8 +1934,8 @@
                         "nl": "Informatie update interval associatie groep 2"
                     },
                     "hint": {
-                        "en": "This parameter indicates how often the Smart Dimmer should send an update kWh (Kilo Watt Hour)",
-                        "nl": "Deze parameter geeft aan hoe vaak de Smart Dimmer een update met kWh (Kilo Watt Uur) stuurt"
+                        "en": "This parameter indicates how often the Smart Dimmer should send an update with new information to devices in association group 2",
+                        "nl": "Deze parameter geeft aan hoe vaak de Smart Dimmer een update met nieuwe informatie naar apparaten in de tweede associatie group zou moeten sturen"
                     },
                     "attr": {
                         "min": 1,

--- a/app.json
+++ b/app.json
@@ -1634,14 +1634,14 @@
                         "value": 2
                     },
                     {
-                        "id": 91,
-                        "size": 4,
-                        "value": 3
+                        "id": 90,
+                        "size": 1,
+                        "value": 1
                     },
                     {
-                        "id": 101,
-                        "size": 4,
-                        "value": 4
+                        "id": 91,
+                        "size": 2,
+                        "value": 3
                     },
                     {
                         "id": 111,
@@ -1654,7 +1654,8 @@
             "capabilities": [
                 "onoff",
                 "dim",
-                "measure_power"
+                "measure_power",
+                "meter_power"
             ],
             "images": {
                 "large": "/drivers/ZW099/assets/images/large.png",
@@ -1679,7 +1680,7 @@
                     "type": "dropdown",
                     "label": {
                         "en": "Configure the output load status after re-power",
-                        "nl": "Zet na een stroomonderbreking deze Smart Switch:"
+                        "nl": "Zet na een stroomonderbreking deze status"
                     },
                     "value": "0",
                     "hint": {
@@ -1714,12 +1715,12 @@
                     "id": 80,
                     "type": "checkbox",
                     "label": {
-                        "en": "Notify associated devices when Smart Switch is toggled",
-                        "nl": "Stuur notificaties naar geassocieerde apparaten wanneer de Smart Switch aan of uit wordt gezet"
+                        "en": "Notify associated devices when Smart Dimmer is toggled",
+                        "nl": "Stuur notificaties naar geassocieerde apparaten wanneer de Smart Dimmer aan of uit wordt gezet"
                     },
                     "hint": {
-                        "en": "Enable this to let Homey know when you or another device turned the Smart Switch on or off",
-                        "nl": "Zet dit aan om Homey te laten weten wanneer jij of een ander apparaat de Smart Switch aan of uit hebt gezet"
+                        "en": "Enable this to let Homey know when you or another device turned the Smart Dimmer on or off",
+                        "nl": "Zet dit aan om Homey te laten weten wanneer jij of een ander apparaat de Smart Dimmer aan of uit hebt gezet"
                     },
                     "value": true
                 },
@@ -1754,7 +1755,7 @@
                             "id": "2",
                             "label": {
                                 "en": "Night light mode",
-                                "nl": "Nacht licht modus"
+                                "nl": "Nacht lamp modus"
                             }
                         }
                     ]
@@ -1767,98 +1768,14 @@
                         "nl": "Minimale verandering in wattage nodig voor het verzenden van een update"
                     },
                     "value": 3,
-                    "min": 0,
-                    "max": 60000,
+                    "attr": {
+                        "min": 0,
+                        "max": 60000
+                    },
                     "hint": {
                         "en": "Minimum change of wattage value needed before value is updated",
                         "nl": "Minimale verandering in wattage nodig voor het verzenden van een update"
                     }
-                },
-                {
-                    "id": 101,
-                    "type": "dropdown",
-                    "label": {
-                        "en": "Information reports send to association group 1",
-                        "nl": "Informatie updates naar associatie groep 1"
-                    },
-                    "hint": {
-                        "en": "Which information needs to be send to devices in association group 1",
-                        "nl": "Welke informatie moet naar apparaten in associatie groep 1 worden gestuurd"
-                    },
-                    "value": "4",
-                    "values": [
-                        {
-                            "id": "1",
-                            "label": {
-                                "en": "Voltage (V)",
-                                "nl": "Voltage (V)"
-                            }
-                        },
-                        {
-                            "id": "2",
-                            "label": {
-                                "en": "Current (A)",
-                                "nl": "Current (A)"
-                            }
-                        },
-                        {
-                            "id": "4",
-                            "label": {
-                                "en": "Power (Watt)",
-                                "nl": "Vermogen (Watt)"
-                            }
-                        },
-                        {
-                            "id": "8",
-                            "label": {
-                                "en": "Energy (kWh)",
-                                "nl": "Energie (kWh)"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "id": 102,
-                    "type": "dropdown",
-                    "label": {
-                        "en": "Information reports send to association group 2",
-                        "nl": "Informatie updates naar associatie groep 2"
-                    },
-                    "hint": {
-                        "en": "Which information needs to be send to devices in association group 2",
-                        "nl": "Welke informatie moet naar apparaten in associatie groep 2 worden gestuurd"
-                    },
-                    "value": "4",
-                    "values": [
-                        {
-                            "id": "1",
-                            "label": {
-                                "en": "Voltage (V)",
-                                "nl": "Voltage (V)"
-                            }
-                        },
-                        {
-                            "id": "2",
-                            "label": {
-                                "en": "Current (A)",
-                                "nl": "Current (A)"
-                            }
-                        },
-                        {
-                            "id": "4",
-                            "label": {
-                                "en": "Power (Watt)",
-                                "nl": "Vermogen (Watt)"
-                            }
-                        },
-                        {
-                            "id": "8",
-                            "label": {
-                                "en": "Energy (kWh)",
-                                "nl": "Energie (kWh)"
-                            }
-                        }
-                    ]
                 },
                 {
                     "id": 103,
@@ -1911,11 +1828,13 @@
                         "nl": "Informatie update interval associatie groep 1"
                     },
                     "hint": {
-                        "en": "This parameter indicates how often the Smart Switch should send an update with new information to devices in association group 1",
-                        "nl": "Deze parameter geeft aan hoe vaak de Smart Switch een update met nieuwe informatie naar apparaten in de eerste associatie group zou moeten sturen"
+                        "en": "This parameter indicates how often the Smart Dimmer should send an update Wattage",
+                        "nl": "Deze parameter geeft aan hoe vaak de Smart Dimmer een update met Wattage stuurt"
                     },
-                    "min": 1,
-                    "max": 268435456,
+                    "attr": {
+                        "min": 1,
+                        "max": 268435456
+                    },
                     "value": 15
                 },
                 {
@@ -1926,11 +1845,13 @@
                         "nl": "Informatie update interval associatie groep 2"
                     },
                     "hint": {
-                        "en": "This parameter indicates how often the Smart Switch should send an update with new information to devices in association group 2",
-                        "nl": "Deze parameter geeft aan hoe vaak de Smart Switch een update met nieuwe informatie naar apparaten in de tweede associatie group zou moeten sturen"
+                        "en": "This parameter indicates how often the Smart Dimmer should send an update kWh (Kilo Watt Hour)",
+                        "nl": "Deze parameter geeft aan hoe vaak de Smart Dimmer een update met kWh (Kilo Watt Uur) stuurt"
                     },
-                    "min": 1,
-                    "max": 268435456,
+                    "attr": {
+                        "min": 1,
+                        "max": 268435456
+                    },
                     "value": 600
                 },
                 {
@@ -1941,11 +1862,13 @@
                         "nl": "Informatie update interval associatie groep 3"
                     },
                     "hint": {
-                        "en": "This parameter indicates how often the Smart Switch should send an update with new information to devices in association group 3",
-                        "nl": "Deze parameter geeft aan hoe vaak de Smart Switch een update met nieuwe informatie naar apparaten in de derde associatie group zou moeten sturen"
+                        "en": "This parameter indicates how often the Smart Dimmer should send an update with new information to devices in association group 3",
+                        "nl": "Deze parameter geeft aan hoe vaak de Smart Dimmer een update met nieuwe informatie naar apparaten in de derde associatie group zou moeten sturen"
                     },
-                    "min": 1,
-                    "max": 268435456,
+                    "attr": {
+                        "min": 1,
+                        "max": 268435456
+                    },
                     "value": 600
                 }
             ]

--- a/drivers/ZW099/driver.js
+++ b/drivers/ZW099/driver.js
@@ -23,23 +23,24 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 				command_get: 'BASIC_GET',
 				command_report: 'BASIC_REPORT',
 				command_report_parser: report => {
-					if (report.hasOwnProperty('Current Value')) return report['Current Value'] !== 0;
-					if (report.hasOwnProperty('Value')) return report['Value'] !== 0;
+					if (report.hasOwnProperty('Current Value'))
+						return report['Current Value'] !== 0;
+					
+					if (report.hasOwnProperty('Value'))
+						return report['Value'] !== 0;
 				}
 			}
 		],
+		
 		dim: [
 			{
 				command_class: 'COMMAND_CLASS_SWITCH_MULTILEVEL',
 				command_set: 'SWITCH_MULTILEVEL_SET',
 				command_set_parser: value => {
-
-					// Parse value from 0 - 1 to 0 - 99
-					if (value) value = value * 100;
-					if (value >= 100) value = 99;
+					if (value >= 1) value = 0.99;
 
 					return {
-						'Value': value,
+						'Value': value * 100,
 						'Dimming Duration': 255
 					}
 				}
@@ -49,17 +50,18 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 				command_get: 'BASIC_GET',
 				command_report: 'BASIC_REPORT',
 				command_report_parser: report => {
-					if (report.hasOwnProperty('Value') && !isNaN(report['Value'])) {
-
-						// Parse value from 0 - 99 to 0 -1
-						let value = report['Value'];
-						if (value) value = value / 100;
-
-						return value;
+					if (report.hasOwnProperty('Current Value') &&
+					!isNaN(report['Value'])) {
+						return report['Current Value'] / 100;
+					
+					if (report.hasOwnProperty('Value') &&
+					!isNaN(report['Value'])) {
+						return report['Value'] / 100;
 					}
 				}
 			}
 		],
+		
 		measure_power: {
 			command_class: 'COMMAND_CLASS_METER',
 			command_get: 'METER_GET',
@@ -72,14 +74,42 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 				}
 			},
 			command_report: 'METER_REPORT',
-			command_report_parser: report => report['Meter Value (Parsed)']
+			command_report_parser: report => {
+				if (report.hasOwnProperty('Properties1') &&
+				report.Properties1.hasOwnProperty('Scale') &&
+				report.Properties1['Scale'] === 0)
+					return report['Meter Value (Parsed)'];
+				
+				return null;
+			}
+		},
+		
+		meter_power: {
+			command_class: 'COMMAND_CLASS_METER',
+			command_get: 'METER_GET',
+			command_get_parser: () => {
+				return {
+					'Sensor Type': 'Electric meter',
+					'Properties1': {
+						'Scale': 2
+					}
+				}
+			},
+			command_report: 'METER_REPORT',
+			command_report_parser: report => {
+				if (report.hasOwnProperty('Properties1') &&
+				report.Properties1.hasOwnProperty('Scale') &&
+				report.Properties1['Scale'] === 2)
+					return report['Meter Value (Parsed)'];
+				
+				return null;
+			}
 		}
 	},
 	settings: {
 		3: {
 			index: 3,
 			size: 1,
-			parser: input => new Buffer([(input) ? 1 : 0])
 		},
 		20: {
 			index: 20,
@@ -96,10 +126,6 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 		},
 		91: {
 			index: 91,
-			size: 4
-		},
-		101: {
-			index: 101,
 			size: 4
 		},
 		102: {


### PR DESCRIPTION
app.json:
add defaultConfig "90"
change defaultConfig size "91" => 2
remove defaultConfig "101" default anyway
add meter_power capability
typo label "Configure the output load status after re-power"
move min/max into attribute
remove setting "101", "102" can stop data to homey
change setting hint "111", "112", "113"

driver.js:
coding consistency
change max range parser for dimmer
add extra check for dimmer "dim" that onoff was already using
add meter_power capability
remove checkbox parser
remove setting "101" can stop data to homey
