### PR TITLE
Merge PR Ted Tolboom: change meter report percentage thresholds to 30%, closes #43

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 This app adds support for Aeotec devices in Homey.
 
 ###Changelog:
+**1.2.1**
++ add Power Meter report (%) parameters
+  - ZW075
+  - ZW096
+  - ZW099
+
 **1.2.0**
 * Coding Clean-up
 * More Default Configuration fixes

--- a/app.json
+++ b/app.json
@@ -1164,7 +1164,12 @@
           {
             "id": 91,
             "size": 2,
-            "value": 3
+            "value": 25
+          },
+          {
+            "id": 92,
+            "size": 1,
+            "value": 30
           },
           {
             "id": 101,
@@ -1294,7 +1299,7 @@
             "en": "Minimum wattage change needed before an update report is send",
             "nl": "Minimale verandering in wattage nodig voor het verzenden van een update"
           },
-          "value": 3,
+          "value": 25,
           "attr": {
             "min": 0,
             "max": 32000
@@ -1302,6 +1307,23 @@
           "hint": {
             "en": "Minimum change of wattage value needed before value is updated",
             "nl": "Minimale verandering in wattage nodig voor het verzenden van een update"
+          }
+        },
+        {
+          "id": 92,
+          "type": "number",
+          "label": {
+            "en": "Minimum wattage change (%) needed before an update report is send",
+            "nl": "Minimale verandering in wattage (%) nodig voor het verzenden van een update"
+          },
+          "value": 30,
+          "attr": {
+            "min": 0,
+            "max": 100
+          },
+          "hint": {
+            "en": "Minimum change in wattage (%) for a report to be sent.\nRange: 0 - 100",
+            "nl": "Minimale verandering in wattage (%) nodig voor het verzenden van een update.\nBereik: 0 - 100"
           }
         },
         {
@@ -1855,7 +1877,12 @@
           {
             "id": 91,
             "size": 2,
-            "value": 3
+            "value": 25
+          },
+          {
+            "id": 92,
+            "size": 1,
+            "value": 30
           },
           {
             "id": 101,
@@ -1985,7 +2012,7 @@
             "en": "Minimum wattage change needed before an update report is send",
             "nl": "Minimale verandering in wattage nodig voor het verzenden van een update"
           },
-          "value": 3,
+          "value": 25,
           "attr": {
             "min": 0,
             "max": 65355
@@ -1993,6 +2020,23 @@
           "hint": {
             "en": "Minimum change of wattage value needed before value is updated",
             "nl": "Minimale verandering in wattage nodig voor het verzenden van een update"
+          }
+        },
+        {
+          "id": 92,
+          "type": "number",
+          "label": {
+            "en": "Minimum wattage change (%) needed before an update report is send",
+            "nl": "Minimale verandering in wattage (%) nodig voor het verzenden van een update"
+          },
+          "value": 30,
+          "attr": {
+            "min": 0,
+            "max": 100
+          },
+          "hint": {
+            "en": "Minimum change in wattage (%) for a report to be sent.\nRange: 0 - 100",
+            "nl": "Minimale verandering in wattage (%) nodig voor het verzenden van een update.\nBereik: 0 - 100"
           }
         },
         {
@@ -2332,7 +2376,12 @@
           {
             "id": 91,
             "size": 2,
-            "value": 3
+            "value": 25
+          },
+          {
+            "id": 92,
+            "size": 1,
+            "value": 30
           },
           {
             "id": 101,
@@ -2463,7 +2512,7 @@
             "en": "Minimum wattage change needed before an update report is send",
             "nl": "Minimale verandering in wattage nodig voor het verzenden van een update"
           },
-          "value": 3,
+          "value": 25,
           "attr": {
             "min": 0,
             "max": 60000
@@ -2471,6 +2520,23 @@
           "hint": {
             "en": "Minimum change of wattage value needed before value is updated",
             "nl": "Minimale verandering in wattage nodig voor het verzenden van een update"
+          }
+        },
+        {
+          "id": 92,
+          "type": "number",
+          "label": {
+            "en": "Minimum wattage change (%) needed before an update report is send",
+            "nl": "Minimale verandering in wattage (%) nodig voor het verzenden van een update"
+          },
+          "value": 30,
+          "attr": {
+            "min": 0,
+            "max": 100
+          },
+          "hint": {
+            "en": "Minimum change in wattage (%) for a report to be sent.\nRange: 0 - 100",
+            "nl": "Minimale verandering in wattage (%) nodig voor het verzenden van een update.\nBereik: 0 - 100"
           }
         },
         {

--- a/config/drivers/ZW075.json
+++ b/config/drivers/ZW075.json
@@ -43,7 +43,7 @@
 			{
 				"id": 92,
 				"size": 1,
-				"value": 80
+				"value": 30
 			},
 			{
 				"id": 101,
@@ -187,14 +187,14 @@
 				"en": "Minimum wattage change (%) needed before an update report is send",
 				"nl": "Minimale verandering in wattage (%) nodig voor het verzenden van een update"
 			},
-			"value": 80,
+			"value": 30,
 			"attr": {
 				"min": 0,
 				"max": 100
 			},
 			"hint": {
-				"en": "Minimum change in wattage percent (%) for a report to be sent. \nrange: 0 - 100",
-				"nl": "Minimale verandering in wattage procent (%) nodig voor het verzenden van een update. \nbereik: 0 - 100"
+				"en": "Minimum change in wattage (%) for a report to be sent.\nRange: 0 - 100",
+				"nl": "Minimale verandering in wattage (%) nodig voor het verzenden van een update.\nBereik: 0 - 100"
 			}
 		},
 		{

--- a/config/drivers/ZW075.json
+++ b/config/drivers/ZW075.json
@@ -20,7 +20,8 @@
 			1,
 			2
 		],
-		"defaultConfiguration": [{
+		"defaultConfiguration": [
+			{
 				"id": 3,
 				"size": 1,
 				"value": 1
@@ -67,7 +68,8 @@
 		"large": "/drivers/ZW075/assets/images/large.png",
 		"small": "/drivers/ZW075/assets/images/small.png"
 	},
-	"settings": [{
+	"settings": [
+		{
 			"id": 3,
 			"type": "checkbox",
 			"label": {
@@ -92,7 +94,8 @@
 				"en": "When the device has been re-powered, it will set it status as configured",
 				"nl": "Wanneer de Smart Switch zonder stroom heeft gezeten, zal deze automatisch terug worden gezet naar deze status"
 			},
-			"values": [{
+			"values": [
+				{
 					"id": "0",
 					"label": {
 						"en": "Status before re-power",
@@ -140,7 +143,8 @@
 				"nl": "Deze parameter past het gedrag van de LED aan"
 			},
 			"value": "0",
-			"values": [{
+			"values": [
+				{
 					"id": "0",
 					"label": {
 						"en": "LED color follows load",
@@ -209,7 +213,8 @@
 				"nl": "Welke informatie moet naar apparaten in associatie groep 2 worden gestuurd"
 			},
 			"value": "8",
-			"values": [{
+			"values": [
+				{
 					"id": "0",
 					"label": {
 						"en": "Nothing",
@@ -272,7 +277,8 @@
 				"nl": "Welke informatie moet naar apparaten in associatie groep 3 worden gestuurd"
 			},
 			"value": "0",
-			"values": [{
+			"values": [
+				{
 					"id": "0",
 					"label": {
 						"en": "Nothing",

--- a/config/drivers/ZW075.json
+++ b/config/drivers/ZW075.json
@@ -20,8 +20,7 @@
 			1,
 			2
 		],
-		"defaultConfiguration": [
-			{
+		"defaultConfiguration": [{
 				"id": 3,
 				"size": 1,
 				"value": 1
@@ -39,7 +38,12 @@
 			{
 				"id": 91,
 				"size": 2,
-				"value": 3
+				"value": 25
+			},
+			{
+				"id": 92,
+				"size": 1,
+				"value": 80
 			},
 			{
 				"id": 101,
@@ -63,8 +67,7 @@
 		"large": "/drivers/ZW075/assets/images/large.png",
 		"small": "/drivers/ZW075/assets/images/small.png"
 	},
-	"settings": [
-		{
+	"settings": [{
 			"id": 3,
 			"type": "checkbox",
 			"label": {
@@ -89,8 +92,7 @@
 				"en": "When the device has been re-powered, it will set it status as configured",
 				"nl": "Wanneer de Smart Switch zonder stroom heeft gezeten, zal deze automatisch terug worden gezet naar deze status"
 			},
-			"values": [
-				{
+			"values": [{
 					"id": "0",
 					"label": {
 						"en": "Status before re-power",
@@ -138,8 +140,7 @@
 				"nl": "Deze parameter past het gedrag van de LED aan"
 			},
 			"value": "0",
-			"values": [
-				{
+			"values": [{
 					"id": "0",
 					"label": {
 						"en": "LED color follows load",
@@ -169,7 +170,7 @@
 				"en": "Minimum wattage change needed before an update report is send",
 				"nl": "Minimale verandering in wattage nodig voor het verzenden van een update"
 			},
-			"value": 3,
+			"value": 25,
 			"attr": {
 				"min": 0,
 				"max": 32000
@@ -177,6 +178,23 @@
 			"hint": {
 				"en": "Minimum change of wattage value needed before value is updated",
 				"nl": "Minimale verandering in wattage nodig voor het verzenden van een update"
+			}
+		},
+		{
+			"id": 92,
+			"type": "number",
+			"label": {
+				"en": "Minimum wattage change (%) needed before an update report is send",
+				"nl": "Minimale verandering in wattage (%) nodig voor het verzenden van een update"
+			},
+			"value": 80,
+			"attr": {
+				"min": 0,
+				"max": 100
+			},
+			"hint": {
+				"en": "Minimum change in wattage percent (%) for a report to be sent. \nrange: 0 - 100",
+				"nl": "Minimale verandering in wattage procent (%) nodig voor het verzenden van een update. \nbereik: 0 - 100"
 			}
 		},
 		{
@@ -191,8 +209,7 @@
 				"nl": "Welke informatie moet naar apparaten in associatie groep 2 worden gestuurd"
 			},
 			"value": "8",
-			"values": [
-				{
+			"values": [{
 					"id": "0",
 					"label": {
 						"en": "Nothing",
@@ -255,8 +272,7 @@
 				"nl": "Welke informatie moet naar apparaten in associatie groep 3 worden gestuurd"
 			},
 			"value": "0",
-			"values": [
-				{
+			"values": [{
 					"id": "0",
 					"label": {
 						"en": "Nothing",

--- a/config/drivers/ZW096.json
+++ b/config/drivers/ZW096.json
@@ -16,8 +16,7 @@
 		"associationGroups": [
 			1
 		],
-		"defaultConfiguration": [
-			{
+		"defaultConfiguration": [{
 				"id": 3,
 				"size": 1,
 				"value": 1
@@ -35,7 +34,12 @@
 			{
 				"id": 91,
 				"size": 2,
-				"value": 3
+				"value": 25
+			},
+			{
+				"id": 92,
+				"size": 1,
+				"value": 80
 			},
 			{
 				"id": 101,
@@ -59,8 +63,7 @@
 		"large": "/drivers/ZW096/assets/images/large.png",
 		"small": "/drivers/ZW096/assets/images/small.png"
 	},
-	"settings": [
-		{
+	"settings": [{
 			"id": 3,
 			"type": "checkbox",
 			"label": {
@@ -85,8 +88,7 @@
 				"en": "When the device has been re-powered, it will set it status as configured",
 				"nl": "Wanneer de Smart Switch zonder stroom heeft gezeten, zal deze automatisch terug worden gezet naar deze status"
 			},
-			"values": [
-				{
+			"values": [{
 					"id": "0",
 					"label": {
 						"en": "Status before re-power",
@@ -134,8 +136,7 @@
 				"nl": "Deze parameter past het gedrag van de LED aan"
 			},
 			"value": "0",
-			"values": [
-				{
+			"values": [{
 					"id": "0",
 					"label": {
 						"en": "LED color follows load",
@@ -165,7 +166,7 @@
 				"en": "Minimum wattage change needed before an update report is send",
 				"nl": "Minimale verandering in wattage nodig voor het verzenden van een update"
 			},
-			"value": 3,
+			"value": 25,
 			"attr": {
 				"min": 0,
 				"max": 65355
@@ -173,6 +174,23 @@
 			"hint": {
 				"en": "Minimum change of wattage value needed before value is updated",
 				"nl": "Minimale verandering in wattage nodig voor het verzenden van een update"
+			}
+		},
+		{
+			"id": 92,
+			"type": "number",
+			"label": {
+				"en": "Minimum wattage change (%) needed before an update report is send",
+				"nl": "Minimale verandering in wattage (%) nodig voor het verzenden van een update"
+			},
+			"value": 80,
+			"attr": {
+				"min": 0,
+				"max": 100
+			},
+			"hint": {
+				"en": "Minimum change in wattage percent (%) for a report to be sent. \nrange: 0 - 100",
+				"nl": "Minimale verandering in wattage procent (%) nodig voor het verzenden van een update. \nbereik: 0 - 100"
 			}
 		},
 		{
@@ -187,8 +205,7 @@
 				"nl": "Welke informatie moet naar apparaten in associatie groep 1 worden gestuurd"
 			},
 			"value": "12",
-			"values": [
-				{
+			"values": [{
 					"id": "1",
 					"label": {
 						"en": "Voltage (V)",
@@ -244,8 +261,7 @@
 				"nl": "Welke informatie moet naar apparaten in associatie groep 2 worden gestuurd"
 			},
 			"value": "8",
-			"values": [
-				{
+			"values": [{
 					"id": "0",
 					"label": {
 						"en": "Nothing",
@@ -308,8 +324,7 @@
 				"nl": "Welke informatie moet naar apparaten in associatie groep 3 worden gestuurd"
 			},
 			"value": "0",
-			"values": [
-				{
+			"values": [{
 					"id": "0",
 					"label": {
 						"en": "Nothing",

--- a/config/drivers/ZW096.json
+++ b/config/drivers/ZW096.json
@@ -16,7 +16,8 @@
 		"associationGroups": [
 			1
 		],
-		"defaultConfiguration": [{
+		"defaultConfiguration": [
+			{
 				"id": 3,
 				"size": 1,
 				"value": 1
@@ -63,7 +64,8 @@
 		"large": "/drivers/ZW096/assets/images/large.png",
 		"small": "/drivers/ZW096/assets/images/small.png"
 	},
-	"settings": [{
+	"settings": [
+		{
 			"id": 3,
 			"type": "checkbox",
 			"label": {
@@ -88,7 +90,8 @@
 				"en": "When the device has been re-powered, it will set it status as configured",
 				"nl": "Wanneer de Smart Switch zonder stroom heeft gezeten, zal deze automatisch terug worden gezet naar deze status"
 			},
-			"values": [{
+			"values": [
+				{
 					"id": "0",
 					"label": {
 						"en": "Status before re-power",
@@ -136,7 +139,8 @@
 				"nl": "Deze parameter past het gedrag van de LED aan"
 			},
 			"value": "0",
-			"values": [{
+			"values": [
+				{
 					"id": "0",
 					"label": {
 						"en": "LED color follows load",
@@ -205,7 +209,8 @@
 				"nl": "Welke informatie moet naar apparaten in associatie groep 1 worden gestuurd"
 			},
 			"value": "12",
-			"values": [{
+			"values": [
+				{
 					"id": "1",
 					"label": {
 						"en": "Voltage (V)",
@@ -261,7 +266,8 @@
 				"nl": "Welke informatie moet naar apparaten in associatie groep 2 worden gestuurd"
 			},
 			"value": "8",
-			"values": [{
+			"values": [
+				{
 					"id": "0",
 					"label": {
 						"en": "Nothing",
@@ -324,7 +330,8 @@
 				"nl": "Welke informatie moet naar apparaten in associatie groep 3 worden gestuurd"
 			},
 			"value": "0",
-			"values": [{
+			"values": [
+				{
 					"id": "0",
 					"label": {
 						"en": "Nothing",

--- a/config/drivers/ZW096.json
+++ b/config/drivers/ZW096.json
@@ -39,7 +39,7 @@
 			{
 				"id": 92,
 				"size": 1,
-				"value": 80
+				"value": 30
 			},
 			{
 				"id": 101,
@@ -183,14 +183,14 @@
 				"en": "Minimum wattage change (%) needed before an update report is send",
 				"nl": "Minimale verandering in wattage (%) nodig voor het verzenden van een update"
 			},
-			"value": 80,
+			"value": 30,
 			"attr": {
 				"min": 0,
 				"max": 100
 			},
 			"hint": {
-				"en": "Minimum change in wattage percent (%) for a report to be sent. \nrange: 0 - 100",
-				"nl": "Minimale verandering in wattage procent (%) nodig voor het verzenden van een update. \nbereik: 0 - 100"
+				"en": "Minimum change in wattage (%) for a report to be sent.\nRange: 0 - 100",
+				"nl": "Minimale verandering in wattage (%) nodig voor het verzenden van een update.\nBereik: 0 - 100"
 			}
 		},
 		{

--- a/config/drivers/ZW099.json
+++ b/config/drivers/ZW099.json
@@ -17,8 +17,7 @@
 			1,
 			2
 		],
-		"defaultConfiguration": [
-			{
+		"defaultConfiguration": [{
 				"id": 3,
 				"size": 1,
 				"value": 1
@@ -36,7 +35,12 @@
 			{
 				"id": 91,
 				"size": 2,
-				"value": 3
+				"value": 25
+			},
+			{
+				"id": 92,
+				"size": 1,
+				"value": 80
 			},
 			{
 				"id": 101,
@@ -61,8 +65,7 @@
 		"large": "/drivers/ZW099/assets/images/large.png",
 		"small": "/drivers/ZW099/assets/images/small.png"
 	},
-	"settings": [
-		{
+	"settings": [{
 			"id": 3,
 			"type": "checkbox",
 			"label": {
@@ -87,8 +90,7 @@
 				"en": "When the device has been re-powered, it will set it status as configured",
 				"nl": "Wanneer de Smart Switch zonder stroom heeft gezeten, zal deze automatisch terug worden gezet naar deze status"
 			},
-			"values": [
-				{
+			"values": [{
 					"id": "0",
 					"label": {
 						"en": "Status before re-power",
@@ -136,8 +138,7 @@
 				"nl": "Deze parameter past het gedrag van de LED aan"
 			},
 			"value": "0",
-			"values": [
-				{
+			"values": [{
 					"id": "0",
 					"label": {
 						"en": "LED color follows load",
@@ -164,10 +165,10 @@
 			"id": 91,
 			"type": "number",
 			"label": {
-				"en": "Minimum wattage change needed before an update report is send",
-				"nl": "Minimale verandering in wattage nodig voor het verzenden van een update"
+				"en": "Minimum wattage change (W) needed before an update report is send",
+				"nl": "Minimale verandering in wattage (W) nodig voor het verzenden van een update"
 			},
-			"value": 3,
+			"value": 25,
 			"attr": {
 				"min": 0,
 				"max": 60000
@@ -175,6 +176,23 @@
 			"hint": {
 				"en": "Minimum change of wattage value needed before value is updated",
 				"nl": "Minimale verandering in wattage nodig voor het verzenden van een update"
+			}
+		},
+		{
+			"id": 92,
+			"type": "number",
+			"label": {
+				"en": "Minimum wattage change (%) needed before an update report is send",
+				"nl": "Minimale verandering in wattage (%) nodig voor het verzenden van een update"
+			},
+			"value": 80,
+			"attr": {
+				"min": 0,
+				"max": 100
+			},
+			"hint": {
+				"en": "Minimum change in wattage percent (%) for a report to be sent. \nrange: 0 - 100",
+				"nl": "Minimale verandering in wattage procent (%) nodig voor het verzenden van een update. \nbereik: 0 - 100"
 			}
 		},
 		{
@@ -189,8 +207,7 @@
 				"nl": "Welke informatie moet naar apparaten in associatie groep 2 worden gestuurd"
 			},
 			"value": "8",
-			"values": [
-				{
+			"values": [{
 					"id": "0",
 					"label": {
 						"en": "Nothing",
@@ -253,8 +270,7 @@
 				"nl": "Welke informatie moet naar apparaten in associatie groep 3 worden gestuurd"
 			},
 			"value": "0",
-			"values": [
-				{
+			"values": [{
 					"id": "0",
 					"label": {
 						"en": "Nothing",

--- a/config/drivers/ZW099.json
+++ b/config/drivers/ZW099.json
@@ -40,7 +40,7 @@
 			{
 				"id": 92,
 				"size": 1,
-				"value": 80
+				"value": 30
 			},
 			{
 				"id": 101,
@@ -165,8 +165,8 @@
 			"id": 91,
 			"type": "number",
 			"label": {
-				"en": "Minimum wattage change (W) needed before an update report is send",
-				"nl": "Minimale verandering in wattage (W) nodig voor het verzenden van een update"
+				"en": "Minimum wattage change needed before an update report is send",
+				"nl": "Minimale verandering in wattage nodig voor het verzenden van een update"
 			},
 			"value": 25,
 			"attr": {
@@ -185,14 +185,14 @@
 				"en": "Minimum wattage change (%) needed before an update report is send",
 				"nl": "Minimale verandering in wattage (%) nodig voor het verzenden van een update"
 			},
-			"value": 80,
+			"value": 30,
 			"attr": {
 				"min": 0,
 				"max": 100
 			},
 			"hint": {
-				"en": "Minimum change in wattage percent (%) for a report to be sent. \nrange: 0 - 100",
-				"nl": "Minimale verandering in wattage procent (%) nodig voor het verzenden van een update. \nbereik: 0 - 100"
+				"en": "Minimum change in wattage (%) for a report to be sent.\nRange: 0 - 100",
+				"nl": "Minimale verandering in wattage (%) nodig voor het verzenden van een update.\nBereik: 0 - 100"
 			}
 		},
 		{

--- a/config/drivers/ZW099.json
+++ b/config/drivers/ZW099.json
@@ -17,7 +17,8 @@
 			1,
 			2
 		],
-		"defaultConfiguration": [{
+		"defaultConfiguration": [
+			{
 				"id": 3,
 				"size": 1,
 				"value": 1
@@ -65,7 +66,8 @@
 		"large": "/drivers/ZW099/assets/images/large.png",
 		"small": "/drivers/ZW099/assets/images/small.png"
 	},
-	"settings": [{
+	"settings": [
+		{
 			"id": 3,
 			"type": "checkbox",
 			"label": {
@@ -90,7 +92,8 @@
 				"en": "When the device has been re-powered, it will set it status as configured",
 				"nl": "Wanneer de Smart Switch zonder stroom heeft gezeten, zal deze automatisch terug worden gezet naar deze status"
 			},
-			"values": [{
+			"values": [
+				{
 					"id": "0",
 					"label": {
 						"en": "Status before re-power",
@@ -138,7 +141,8 @@
 				"nl": "Deze parameter past het gedrag van de LED aan"
 			},
 			"value": "0",
-			"values": [{
+			"values": [
+				{
 					"id": "0",
 					"label": {
 						"en": "LED color follows load",
@@ -207,7 +211,8 @@
 				"nl": "Welke informatie moet naar apparaten in associatie groep 2 worden gestuurd"
 			},
 			"value": "8",
-			"values": [{
+			"values": [
+				{
 					"id": "0",
 					"label": {
 						"en": "Nothing",
@@ -270,7 +275,8 @@
 				"nl": "Welke informatie moet naar apparaten in associatie groep 3 worden gestuurd"
 			},
 			"value": "0",
-			"values": [{
+			"values": [
+				{
 					"id": "0",
 					"label": {
 						"en": "Nothing",

--- a/drivers/ZW075/driver.js
+++ b/drivers/ZW075/driver.js
@@ -7,8 +7,7 @@ const ZwaveDriver = require('homey-zwavedriver');
 
 module.exports = new ZwaveDriver(path.basename(__dirname), {
 	capabilities: {
-		onoff: [
-			{
+		onoff: [{
 				command_class: 'COMMAND_CLASS_SWITCH_BINARY',
 				command_set: 'SWITCH_BINARY_SET',
 				command_set_parser: value => ({
@@ -85,6 +84,10 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 		91: {
 			index: 91,
 			size: 2,
+		},
+		92: {
+			index: 92,
+			size: 1,
 		},
 		102: {
 			index: 102,

--- a/drivers/ZW096/driver.js
+++ b/drivers/ZW096/driver.js
@@ -7,8 +7,7 @@ const ZwaveDriver = require('homey-zwavedriver');
 
 module.exports = new ZwaveDriver(path.basename(__dirname), {
 	capabilities: {
-		onoff: [
-			{
+		onoff: [{
 				command_class: 'COMMAND_CLASS_SWITCH_BINARY',
 				command_set: 'SWITCH_BINARY_SET',
 				command_set_parser: value => ({
@@ -89,7 +88,11 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 		},
 		91: {
 			index: 91,
-			size: 4,
+			size: 2,
+		},
+		92: {
+			index: 92,
+			size: 1,
 		},
 		101: {
 			index: 101,

--- a/drivers/ZW099/driver.js
+++ b/drivers/ZW099/driver.js
@@ -7,8 +7,7 @@ const ZwaveDriver = require('homey-zwavedriver');
 
 module.exports = new ZwaveDriver(path.basename(__dirname), {
 	capabilities: {
-		onoff: [
-			{
+		onoff: [{
 				command_class: 'COMMAND_CLASS_SWITCH_MULTILEVEL',
 				command_set: 'SWITCH_MULTILEVEL_SET',
 				command_set_parser: value => ({
@@ -27,8 +26,7 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 				},
 			},
 		],
-		dim: [
-			{
+		dim: [{
 				command_class: 'COMMAND_CLASS_SWITCH_MULTILEVEL',
 				command_set: 'SWITCH_MULTILEVEL_SET',
 				command_set_parser: value => {
@@ -115,6 +113,10 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 		91: {
 			index: 91,
 			size: 2,
+		},
+		92: {
+			index: 92,
+			size: 1,
 		},
 		102: {
 			index: 102,


### PR DESCRIPTION
This will prevent report overload, initially the PR proposed to use 80 as threshold, but this seemed a bit too drastic in our opinion. A threshold of 30 will pick up major changes (next to on/off) but will filter out the minor variances that produce the report overload.