### PR TITLE
Add additional productTypeIds for wallmote quad and keyfob

### DIFF
--- a/app.json
+++ b/app.json
@@ -1735,7 +1735,8 @@
         "manufacturerId": 134,
         "productTypeId": [
           1,
-          513
+          513,
+	  257
         ],
         "productId": [
           22,
@@ -3620,7 +3621,8 @@
           134
         ],
         "productTypeId": [
-          2
+          2,
+	  258
         ],
         "productId": [
           130


### PR DESCRIPTION
I just picked up a Wallmote Quad and Keyfob in Canada and found they did not work with the included productTypeIds. Possibly a difference between the North American and European editions? Adding these IDs allowed the devices to be added successfully.