### PR TITLE
Added Product Type ID for AUS/NZ devices

### DIFF
--- a/ZW111-C.json
+++ b/ZW111-C.json
@@ -1,0 +1,267 @@
+{
+	"id": "ZW111-C",
+	"class": "light",
+	"name": {
+		"en": "Nano Dimmer"
+	},
+	"capabilities": [
+		"onoff",
+		"dim",
+		"measure_power",
+		"meter_power"
+	],
+	"images": {
+		"large": "/drivers/ZW111-C/assets/images/large.png",
+		"small": "/drivers/ZW111-C/assets/images/small.png"
+	},
+	"zwave": {
+		"manufacturerId": [
+			134
+		],
+		"productTypeId": [
+			3, 515
+		],
+		"productId": [
+			111
+		],
+		"learnmode": {
+			"instruction": {
+				"en": "Short press the action button on the back of the Nano Dimmer.",
+                "nl": "Druk kort op de actie knop op de achterkant van de Nano Dimmer."
+			}
+		},
+		"productDocumentation": "http://Products.Z-WaveAlliance.org/ProductManual/File?folder=&filename=Manuals/2135/Aeon Labs Nano Dimmer manual.pdf",
+		"zwaveAllianceProductId": 2135,
+		"imageRemotePath": "http://products.z-wavealliance.org/ProductImages/Index?productName=ZC10-17015388",
+		"associationGroups": [
+			1,
+			3,
+			4
+		],
+		"defaultConfiguration": [
+			{
+				"id": 80,
+				"value": 3,
+				"size": 1
+			},
+			{
+				"id": 90,
+				"size": 1,
+				"value": 1
+			},
+			{
+				"id": 92,
+				"size": 1,
+				"value": 30
+			}
+		]
+	},
+	"settings": [
+		{
+			"id": 20,
+			"type": "dropdown",
+			"label": {
+				"en": "Configure the output load status after re-power",
+				"nl": "Zet na een stroomonderbreking deze status"
+			},
+			"value": "0",
+			"hint": {
+				"en": "When the device has been re-powered, it will set it status as configured",
+				"nl": "Wanneer de Smart Switch zonder stroom heeft gezeten, zal deze automatisch terug worden gezet naar deze status"
+			},
+			"values": [
+				{
+					"id": "0",
+					"label": {
+						"en": "Status before re-power",
+						"nl": "Status voor stroomonderbreking"
+					}
+				},
+				{
+					"id": "1",
+					"label": {
+						"en": "Always on",
+						"nl": "Altijd aan"
+					}
+				},
+				{
+					"id": "2",
+					"label": {
+						"en": "Always off",
+						"nl": "Altijd uit"
+					}
+				}
+			]
+		},
+		{
+			"id": 81,
+			"type": "dropdown",
+			"label": {
+				"en": "Reports to association group 3",
+				"nl": "Metingen naar associatie groep 3"
+			},
+			"hint": {
+				"en": "Which reports need to be send automatically per interval for association group 3",
+				"nl": "Welke metingen worden automatisch per interval verzonden naar associatie groep 3"
+			},
+			"value": "1",
+			"values": [
+				{
+					"id": "0",
+					"label": {
+						"en": "Nothing",
+						"nl": "Niets"
+					}
+				},
+				{
+					"id": "1",
+					"label": {
+						"en": "Basic Set",
+						"nl": "Basic Set"
+					}
+				}
+			]
+		},
+		{
+			"id": 82,
+			"type": "dropdown",
+			"label": {
+				"en": "Reports to association group 4",
+				"nl": "Metingen naar associatie groep 4"
+			},
+			"hint": {
+				"en": "Which reports need to be send automatically per interval for association group 4",
+				"nl": "Welke metingen worden automatisch per interval verzonden naar associatie groep 4"
+			},
+			"value": "1",
+			"values": [
+				{
+					"id": "0",
+					"label": {
+						"en": "Nothing",
+						"nl": "Niets"
+					}
+				},
+				{
+					"id": "1",
+					"label": {
+						"en": "Basic Set",
+						"nl": "Basic Set"
+					}
+				}
+			]
+		},
+		{
+			"id": 91,
+			"type": "number",
+			"label": {
+				"en": "Minimum wattage change needed before an update report is send",
+				"nl": "Minimale verandering in wattage nodig voor het verzenden van een update"
+			},
+			"value": 25,
+			"attr": {
+				"min": 0,
+				"max": 32000
+			},
+			"hint": {
+				"en": "Minimum change of wattage value needed before value is updated",
+				"nl": "Minimale verandering in wattage nodig voor het verzenden van een update"
+			}
+		},
+		{
+			"id": 92,
+			"type": "number",
+			"label": {
+				"en": "Minimum wattage change (%) needed before an update report is send",
+				"nl": "Minimale verandering in wattage (%) nodig voor het verzenden van een update"
+			},
+			"value": 30,
+			"attr": {
+				"min": 0,
+				"max": 100
+			},
+			"hint": {
+				"en": "Minimum change in wattage (%) for a report to be sent.\nRange: 0 - 100",
+				"nl": "Minimale verandering in wattage (%) nodig voor het verzenden van een update.\nBereik: 0 - 100"
+			}
+		},
+		{
+			"id": 120,
+			"type": "dropdown",
+			"label": {
+				"en": "Switch type input 1",
+				"nl": "Schakelaar type input 1"
+			},
+			"value": "0",
+			"values": [
+				{
+					"id": "0",
+					"label": {
+						"en": "Automatic",
+						"nl": "Automatisch"
+					}
+				},
+				{
+					"id": "1",
+					"label": {
+						"en": "Momentary switch",
+						"nl": "Pulsdruk schakelaar"
+					}
+				},
+				{
+					"id": "2",
+					"label": {
+						"en": "3-way switch mode",
+						"nl": "3-way schakel modus"
+					}
+				},
+				{
+					"id": "3",
+					"label": {
+						"en": "2-state switch mode",
+						"nl": "2-state schakel modus"
+					}
+				}
+			]
+		},
+		{
+			"id": 121,
+			"type": "dropdown",
+			"label": {
+				"en": "Switch type input 2",
+				"nl": "Schakelaar type input 2"
+			},
+			"value": "0",
+			"values": [
+				{
+					"id": "0",
+					"label": {
+						"en": "Automatic",
+						"nl": "Automatisch"
+					}
+				},
+				{
+					"id": "1",
+					"label": {
+						"en": "Momentary switch",
+						"nl": "Pulsdruk schakelaar"
+					}
+				},
+				{
+					"id": "2",
+					"label": {
+						"en": "3-way switch mode",
+						"nl": "3-way schakel modus"
+					}
+				},
+				{
+					"id": "3",
+					"label": {
+						"en": "2-state switch mode",
+						"nl": "2-state schakel modus"
+					}
+				}
+			]
+		}
+	]
+}

--- a/ZW112.json
+++ b/ZW112.json
@@ -1,0 +1,118 @@
+{
+	"id": "ZW112",
+	"class": "sensor",
+	"name": {
+		"en": "Door/Window Sensor 6",
+		"nl": "Deur/Raam Sensor 6"
+	},
+	"capabilities": [
+		"alarm_contact",
+		"measure_battery"
+	],
+	"images": {
+		"large": "/drivers/ZW112/assets/images/large.png",
+		"small": "/drivers/ZW112/assets/images/small.png"
+	},
+	"zwave": {
+		"manufacturerId": [
+			134
+		],
+		"productTypeId": [
+			2, 514
+		],
+		"productId": [
+			112
+		],
+		"wakeUpInterval": 300,
+		"learnmode": {
+			"image": "/drivers/ZW112/assets/learnmode.svg",
+			"instruction": {
+				"en": "Short press the action button on the back of the Door/Window Sensor 6.",
+				"nl": "Druk kort op de actie knop op de achterkant van de Deur/Raam Sensor 6"
+			}
+		},
+		"productDocumentation": "http://Products.Z-WaveAlliance.org/ProductManual/File?folder=&filename=Manuals/1615/Door Window Sensor 6 manual.pdf",
+		"pid": 1615,
+		"imageRemotePath": "http://products.z-wavealliance.org/ProductImages/Index?productName=ZC10-16010008",
+		"associationGroups": [
+			1
+		],
+		"associationGroupsOptions": {
+			"1": {
+				"hint": {
+					"en": "Group 1 is assigned to the Lifeline association group and every device has 5 nodes to associate. The sensor binary report, basic set or notification report command can be sent in this group when the Sensor is triggered.",
+					"nl": "Groep 1 is toegewezen aan de Lifeline associatie groep en elk apparaat heeft 5 nodes om te associëren. Sensory binary report, basic set of notification report commando's kunnen worden verstuurd in deze groep wanneer de sensor wordt getriggered."
+				}
+			}
+		}
+	},
+	"settings": [
+		{
+			"id": 1,
+			"value": "0",
+			"label": {
+				"en": "Turn contact alarm on",
+				"nl": "Activeer contact alarm"
+			},
+			"_size": 1,
+			"values": [
+				{
+					"id": "0",
+					"label": {
+						"en": "When there is no contact between the sensor and the magnet strip",
+						"nl": "Wanneer er geen contact is tussen de sensor en de magneet strip"
+					}
+				},
+				{
+					"id": "1",
+					"label": {
+						"en": "When there is contact between the sensor and the magnet strip",
+						"nl": "Wanner er contact is tussen de sensor en de magneet strip"
+					}
+				}
+			],
+			"type": "dropdown"
+		},
+		{
+			"id": 101,
+			"value": true,
+			"label": {
+				"en": "Enable/disable battery check interval",
+				"nl": "Activeer batterij check interval"
+			},
+			"type": "checkbox"
+		},
+		{
+			"id": 111,
+			"value": 86640,
+			"label": {
+				"en": "Low battery checking interval",
+				"nl": "Laag batterij niveau check interval"
+			},
+			"hint": {
+				"en": "Set the interval time of low battery checking. Note: if the value is less than 10, the time unit is second; if the value is more than 10, the interval is 4 minutes, which means if the value is more than 10 and less than 240, the interval time is 4 minutes; if the value is more than 240 and less than 480, the interval is 8 minutes.",
+				"nl": "Stel het batterij niveau check interval in. Als de ingestelde waarde lager is dan 10 is de interval eenheid seconden, als de waarde hoger is dan 10 is het interval 4 minuten, als de waarde hoger is dan 240 en minder dan 480 is het interval 8 minuten"
+			},
+			"_size": 4,
+			"attr": {
+				"min": 0,
+				"max": 2147483647
+			},
+			"type": "number"
+		},
+		{
+			"id": 39,
+			"value": 20,
+			"label": {
+				"en": "Low battery value",
+				"nl": "Laag batterij niveau waarde"
+			},
+			"_size": 1,
+			"attr": {
+				"min": 10,
+				"max": 50
+			},
+			"type": "number"
+		}
+	]
+}

--- a/ZW116.json
+++ b/ZW116.json
@@ -1,0 +1,230 @@
+{
+	"id": "ZW116",
+	"class": "light",
+	"name": {
+		"en": "Nano Switch"
+	},
+	"capabilities": [
+		"onoff",
+		"measure_power",
+		"meter_power"
+	],
+	"images": {
+		"large": "/drivers/ZW116/assets/images/large.png",
+		"small": "/drivers/ZW116/assets/images/small.png"
+	},
+	"zwave": {
+		"manufacturerId": [
+			134
+		],
+		"productTypeId": [
+			3, 515
+		],
+		"productId": [
+			116
+		],
+		"learnmode": {
+			"instruction": {
+				"en": "Short press the action button on the back of the Nano Switch.",
+                "nl": "Druk kort op de actie knop op de achterkant van de Nano Switch."
+			}
+		},
+		"zwaveAllianceProductId": 2320,
+		"associationGroups": [
+			1,
+			3,
+			4
+		],
+		"defaultConfiguration": [
+			{
+				"id": 80,
+				"value": 3,
+				"size": 1
+			},
+			{
+				"id": 90,
+				"size": 1,
+				"value": 1
+			},
+			{
+				"id": 92,
+				"size": 1,
+				"value": 30
+			}
+		]
+	},
+	"settings": [
+		{
+			"id": 20,
+			"type": "dropdown",
+			"label": {
+				"en": "Configure the output load status after re-power",
+				"nl": "Zet na een stroomonderbreking deze status"
+			},
+			"value": "0",
+			"hint": {
+				"en": "When the device has been re-powered, it will set it status as configured",
+				"nl": "Wanneer de Smart Switch zonder stroom heeft gezeten, zal deze automatisch terug worden gezet naar deze status"
+			},
+			"values": [
+				{
+					"id": "0",
+					"label": {
+						"en": "Status before re-power",
+						"nl": "Status voor stroomonderbreking"
+					}
+				},
+				{
+					"id": "1",
+					"label": {
+						"en": "Always on",
+						"nl": "Altijd aan"
+					}
+				},
+				{
+					"id": "2",
+					"label": {
+						"en": "Always off",
+						"nl": "Altijd uit"
+					}
+				}
+			]
+		},
+		{
+			"id": 81,
+			"type": "dropdown",
+			"label": {
+				"en": "Reports to association group 3",
+				"nl": "Metingen naar associatie groep 3"
+			},
+			"hint": {
+				"en": "Which reports need to be send automatically per interval for association group 3",
+				"nl": "Welke metingen worden automatisch per interval verzonden naar associatie groep 3"
+			},
+			"value": "1",
+			"values": [
+				{
+					"id": "0",
+					"label": {
+						"en": "Nothing",
+						"nl": "Niets"
+					}
+				},
+				{
+					"id": "1",
+					"label": {
+						"en": "Basic Set",
+						"nl": "Basic Set"
+					}
+				}
+			]
+		},
+		{
+			"id": 82,
+			"type": "dropdown",
+			"label": {
+				"en": "Reports to association group 4",
+				"nl": "Metingen naar associatie groep 4"
+			},
+			"hint": {
+				"en": "Which reports need to be send automatically per interval for association group 4",
+				"nl": "Welke metingen worden automatisch per interval verzonden naar associatie groep 4"
+			},
+			"value": "1",
+			"values": [
+				{
+					"id": "0",
+					"label": {
+						"en": "Nothing",
+						"nl": "Niets"
+					}
+				},
+				{
+					"id": "1",
+					"label": {
+						"en": "Basic Set",
+						"nl": "Basic Set"
+					}
+				}
+			]
+		},
+		{
+			"id": 120,
+			"type": "dropdown",
+			"label": {
+				"en": "Switch type input 1",
+				"nl": "Schakelaar type input 1"
+			},
+			"value": "0",
+			"values": [
+				{
+					"id": "0",
+					"label": {
+						"en": "Automatic",
+						"nl": "Automatisch"
+					}
+				},
+				{
+					"id": "1",
+					"label": {
+						"en": "Momentary switch",
+						"nl": "Pulsdruk schakelaar"
+					}
+				},
+				{
+					"id": "2",
+					"label": {
+						"en": "3-way switch mode",
+						"nl": "3-way schakel modus"
+					}
+				},
+				{
+					"id": "3",
+					"label": {
+						"en": "2-state switch mode",
+						"nl": "2-state schakel modus"
+					}
+				}
+			]
+		},
+		{
+			"id": 121,
+			"type": "dropdown",
+			"label": {
+				"en": "Switch type input 2",
+				"nl": "Schakelaar type input 2"
+			},
+			"value": "0",
+			"values": [
+				{
+					"id": "0",
+					"label": {
+						"en": "Automatic",
+						"nl": "Automatisch"
+					}
+				},
+				{
+					"id": "1",
+					"label": {
+						"en": "Momentary switch",
+						"nl": "Pulsdruk schakelaar"
+					}
+				},
+				{
+					"id": "2",
+					"label": {
+						"en": "3-way switch mode",
+						"nl": "3-way schakel modus"
+					}
+				},
+				{
+					"id": "3",
+					"label": {
+						"en": "2-state switch mode",
+						"nl": "2-state schakel modus"
+					}
+				}
+			]
+		}
+	]
+}

--- a/ZW117.json
+++ b/ZW117.json
@@ -1,0 +1,61 @@
+{
+	"id": "ZW117",
+	"class": "other",
+	"name": {
+		"en": "Range Extender 6"
+	},
+	"capabilities": [],
+	"images": {
+		"large": "/drivers/ZW117/assets/images/large.png",
+		"small": "/drivers/ZW117/assets/images/small.png"
+	},
+	"zwave": {
+		"manufacturerId": [
+			134
+		],
+		"productTypeId": [
+			4, 516
+		],
+		"productId": [
+			117
+		],
+		"wakeUpInterval": 3600,
+		"learnmode": {
+			"image": "/drivers/ZW117/assets/learnmode.svg",
+			"instruction": {
+				"en": "Press the Z-Wave Button on the Range Extender 6.",
+				"nl": "Druk op de Z-Wave knop op de Range Extender 6."
+			}
+		},
+		"productDocumentation": "http://Products.Z-WaveAlliance.org/ProductManual/File?folder=&filename=Manuals/1998/Range Extender 6 manual.pdf",
+		"pid": 1998,
+		"imageRemotePath": "http://products.z-wavealliance.org/ProductImages/Index?productName=ZC10-16095248",
+		"associationGroups": [
+			1
+		],
+		"associationGroupsOptions": {
+			"1": {
+				"hint": {
+					"en": "The association group 1 is the Z-Wave Lifeline group. The Device Reset Locally Notification CC can be sent to the associated node in association group 1.",
+					"nl": "De associatie groep 1 is de Z-Wave Lifeline groep. Device Reset Locally Notification command class kan worden verstuurd naar de geassocieerde nodes in associate groep 1."
+				}
+			}
+		}
+	},
+	"settings": [
+		{
+			"id": 82,
+			"value": true,
+			"label": {
+				"en": "Status LED",
+				"nl": "Status LED"
+			},
+			"hint": {
+				"en": "Turn on to let the status LED flash green for two seocnds when the Range Extender relays a Z-Wave message",
+				"nl": "Vink aan om de status LED groen te laten knipperen voor twee seconden wanneer de Range Extender een Z-Wave bericht doorstuurt"
+			},
+			"_size": 1,
+			"type": "checkbox"
+		}
+	]
+}

--- a/ZW130.json
+++ b/ZW130.json
@@ -1,0 +1,344 @@
+{
+	"id": "ZW130",
+	"class": "sensor",
+	"name": {
+		"en": "Wallmote Quad"
+	},
+	"capabilities": [
+		"measure_battery",
+		"alarm_battery"
+	],
+	"images": {
+		"large": "/drivers/ZW130/assets/images/large.png",
+		"small": "/drivers/ZW130/assets/images/small.png"
+	},
+	"zwave": {
+		"manufacturerId": [
+			134
+		],
+		"productTypeId": [
+			2, 514
+		],
+		"productId": [
+			130
+		],
+		"wakeUpInterval": 86400,
+		"learnmode": {
+			"image": "/drivers/ZW130/assets/learnmode.svg",
+			"instruction": {
+				"en": "Secure inclusion: Double press the action button on the Wallmote Quad.\n\nUnsecure inclusion: Single press the action button on the Wallmote Quad",
+				"nl": "Beveiligd toevoegen: Druk 2 keer op de actie knop op de Wallmote Quad.\n\nOnbeveiligd toevoegen: Druk 1 keer op de actie knop op de Wallmote Quad"
+			}
+		},
+		"unlearnmode": {
+			"image": "/drivers/ZW130/assets/learnmode.svg",
+			"instruction": {
+				"en": "Press the action button on the Wallmote Quad",
+				"nl": "Druk op de actie knop op de Wallmote Quad"
+			}
+		},
+		"productDocumentation": "http://products.z-wavealliance.org/ProductManual/File?folder=&filename=Manuals/2153/Aeon Labs WallMote Quad manual.pdf",
+		"pid": 2153,
+		"imageRemotePath": "http://products.z-wavealliance.org/ProductImages/Index?productName=ZC10-17035521",
+		"associationGroups": [
+			1
+		],
+		"associationGroupsOptions": {
+			"1": {
+				"hint": {
+					"en": "This is the Z-Wave Lifeline group, it is not recommended to change this.",
+					"nl": "Dit is de Z-Wave Lifeline groep, het is niet aangeraden deze te veranderen."
+				}
+			},
+			"2": {
+				"hint": {
+					"en": "Devices here will receive on and off commands from the topleft touch part.",
+					"nl": "Apparaten hier zullen de aan en uit commando's krijgen van het linksbovenste aanraak gedeelte."
+				}
+			},
+			"3": {
+				"hint": {
+					"en": "Devices here will receive dimming commands from the topleft touch part.",
+					"nl": "Apparaten hier zullen de dimmen commando's krijgen van het linksbovenste aanraak gedeelte."
+				}
+			},
+			"4": {
+				"hint": {
+					"en": "Devices here will receive on and off commands from the topright touch part.",
+					"nl": "Apparaten hier zullen de aan en uit commando's krijgen van het rechtsbovenste aanraak gedeelte."
+				}
+			},
+			"5": {
+				"hint": {
+					"en": "Devices here will receive dimming commands from the topright touch part.",
+					"nl": "Apparaten hier zullen de dimmen commando's krijgen van het rechtsbovenste aanraak gedeelte."
+				}
+			},
+			"6": {
+				"hint": {
+					"en": "Devices here will receive on and off commands from the bottomleft touch part.",
+					"nl": "Apparaten hier zullen de aan en uit commando's krijgen van het linksonderste aanraak gedeelte."
+				}
+			},
+			"7": {
+				"hint": {
+					"en": "Devices here will receive dimming commands from the bottomleft touch part.",
+					"nl": "Apparaten hier zullen de dimmen commando's krijgen van het linksonderste aanraak gedeelte."
+				}
+			},
+			"8": {
+				"hint": {
+					"en": "Devices here will receive on and off commands from the bottomright touch part.",
+					"nl": "Apparaten hier zullen de aan en uit commando's krijgen van het rechtsonderste aanraak gedeelte."
+				}
+			},
+			"9": {
+				"hint": {
+					"en": "Devices here will receive dimming commands from the bottomright touch part.",
+					"nl": "Apparaten hier zullen de dimmen commando's krijgen van het rechtsonderste aanraak gedeelte."
+				}
+			}
+		},
+		"defaultConfiguration": [
+			{
+				"id": 4,
+				"size": 1,
+				"value": 3
+			}
+		]
+	},
+	"settings": [
+		{
+			"id": "touch_sound",
+			"type": "checkbox",
+			"label": {
+				"en": "Touch Sound",
+				"nl": "Aanraak Geluid"
+			},
+			"hint": {
+				"en": "Should the wallmote make sound when you touch its touch part(s).",
+				"nl": "Zal de wallmote geluid maken bij het aanraken van zijn aanraak gedeeltes."
+			},
+			"value": true
+		},
+		{
+			"id": "touch_vibration",
+			"type": "checkbox",
+			"label": {
+				"en": "Touch Vibration",
+				"nl": "Aanraak Trillen"
+			},
+			"hint": {
+				"en": "Should the wallmote vibrate when you touch its touch part(s).",
+				"nl": "Zal de wallmote trillen bij het aanraken van zijn aanraak gedeeltes."
+			},
+			"value": true
+		},
+		{
+			"id": "slide_function",
+			"type": "checkbox",
+			"label": {
+				"en": "Slide Dimming Function",
+				"nl": "Swipe Dim Functie"
+			},
+			"hint": {
+				"en": "Should the dimming when you slide be enabled or not.",
+				"nl": "Zal het dimmen met swipen geactiveerd zijn of niet."
+			},
+			"value": true
+		},
+		{
+			"id": "low_battery",
+			"type": "number",
+			"label": {
+				"en": "Low Battery Level",
+				"nl": "Laag Batterij Niveau"
+			},
+			"hint": {
+				"en": "How low must the battery level be before giving a low battery alarm.\nRange: 10% - 50%",
+				"nl": "Hoe laag moet het batterij niveau zijn voor de batterij laag alarm word gegeven.\nBereik: 10% - 50%"
+			},
+			"value": 20,
+			"attr": {
+				"min": 10,
+				"max": 50
+			}
+		},
+		{
+			"type": "group",
+			"label": {
+					"en": "LED Color When Sending Data",
+					"nl": "LED Kleur Bij Verzenden Data"
+			},
+			"children": [
+				{
+					"id": "rgb_name",
+					"type": "dropdown",
+					"label": {
+						"en": "Color Name",
+						"nl": "Kleur Naam"
+					},
+					"hint": {
+						"en": "* = Unfortunately the LED can't be turned off completely, this is the most faint color",
+						"nl": "* = Helaas kan de LED niet volledig uitgezet worden, dit is de minst felle kleur"
+					},
+					"value": "0,0,255",
+					"values": [
+						{
+							"id": "1,1,1",
+							"label": {
+								"en": "Off *",
+								"nl": "Uit *"
+							}
+						},
+						{
+							"id": "255,0,0",
+							"label": {
+								"en": "Red",
+								"nl": "Rood"
+							}
+						},
+						{
+							"id": "255,127,0",
+							"label": {
+								"en": "Orange",
+								"nl": "Oranje"
+							}
+						},
+						{
+							"id": "255,255,0",
+							"label": {
+								"en": "Yellow",
+								"nl": "Geel"
+							}
+						},
+						{
+							"id": "0,255,0",
+							"label": {
+								"en": "Green",
+								"nl": "Groen"
+							}
+						},
+						{
+							"id": "0,255,255",
+							"label": {
+								"en": "Turquise",
+								"nl": "Turkoois"
+							}
+						},
+						{
+							"id": "0,127,255",
+							"label": {
+								"en": "Cyan",
+								"nl": "Cyaan"
+							}
+						},
+						{
+							"id": "0,0,255",
+							"label": {
+								"en": "Blue",
+								"nl": "Blauw"
+							}
+						},
+						{
+							"id": "255,0,255",
+							"label": {
+								"en": "Pink",
+								"nl": "Roze"
+							}
+						},
+						{
+							"id": "64,0,255",
+							"label": {
+								"en": "Purple",
+								"nl": "Paars"
+							}
+						},
+						{
+							"id": "255,255,255",
+							"label": {
+								"en": "White",
+								"nl": "Wit"
+							}
+						},
+						{
+							"id": "custom",
+							"label": {
+								"en": "Custom",
+								"nl": "Aangepast"
+							}
+						}
+					]
+				},
+				{
+					"id": "rgb_name_level",
+					"type": "number",
+					"label": {
+						"en": "Brightness Namecolor",
+						"nl": "Helderheid Naamkleur"
+					},
+					"hint": {
+						"en": "This will determine the brightness level of the colorname.",
+						"nl": "Dit bepaald de helderheid niveau van de kleurnaam."
+					},
+					"value": 100,
+					"attr": {
+						"min": 0,
+						"max": 100
+					}
+				},
+				{
+					"id": "rgb_r",
+					"type": "number",
+					"label": {
+						"en": "Red",
+						"nl": "Rood"
+					},
+					"hint": {
+						"en": "Range: 0 (off) - 255 (full brightness).\nOne of the colors must have at least 1 as value",
+						"nl": "Bereik: 0 (uit) - 255 (volle helderheid).\nEen van de kleuren moet minstens 1 hebben als waarde"
+					},
+					"value": 0,
+					"attr": {
+						"min": 0,
+						"max": 255
+					}
+				},
+				{
+					"id": "rgb_g",
+					"type": "number",
+					"label": {
+						"en": "Green",
+						"nl": "Groen"
+					},
+					"hint": {
+						"en": "Range: 0 (off) - 255 (full brightness).\nOne of the colors must have at least 1 as value",
+						"nl": "Bereik: 0 (uit) - 255 (volle helderheid).\nEen van de kleuren moet minstens 1 hebben als waarde"
+					},
+					"value": 0,
+					"attr": {
+						"min": 0,
+						"max": 255
+					}
+				},
+				{
+					"id": "rgb_b",
+					"type": "number",
+					"label": {
+						"en": "Blue",
+						"nl": "Blauw"
+					},
+					"hint": {
+						"en": "Range: 0 (off) - 255 (full brightness).\nOne of the colors must have at least 1 as value",
+						"nl": "Bereik: 0 (uit) - 255 (volle helderheid).\nEen van de kleuren moet minstens 1 hebben als waarde"
+					},
+					"value": 255,
+					"attr": {
+						"min": 0,
+						"max": 255
+					}
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
Add Product ID for AUS/NZ devices for the following:

- Nano dimmer ZW111
- Door/Window Sensor 6 ZW112
- Nano single switch ZW116
- Range Extender 6 (z-wave plus) ZW117
- Wallmote Quad ZW130

I did test it thoroughly.