### PR TITLE
Fixed support for DSB45

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ This app adds support for Aeotec devices in Homey.
 
 ### Changelog:
 
+**1.6.5**
+* Fixed support for DSB45
+
 **1.6.4**
 * Add AUS product ids
 * Possible fix for ZW111 dim from Flow

--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
   "name": {
     "en": "Aeotec"
   },
-  "version": "1.6.4",
+  "version": "1.6.5",
   "compatibility": ">=1.0.0",
   "category": [
     "appliances",

--- a/drivers/DSB45/driver.js
+++ b/drivers/DSB45/driver.js
@@ -8,15 +8,29 @@ const ZwaveDriver = require('homey-zwavedriver');
 
 module.exports = new ZwaveDriver(path.basename(__dirname), {
 	capabilities: {
-		alarm_water: {
+		alarm_water: [{
 			command_class: 'COMMAND_CLASS_SENSOR_BINARY',
 			command_get: 'SENSOR_BINARY_GET',
 			command_report: 'SENSOR_BINARY_REPORT',
 			command_report_parser: report => {
 				if (report.hasOwnProperty('Sensor Value')) return report['Sensor Value'] === 'detected an event';
 				return null;
+			}
 			},
-		},
+			{
+			command_class: 'COMMAND_CLASS_BASIC',
+			command_set: 'BASIC_SET',
+			command_get: 'BASIC_GET',
+			command_report: 'BASIC_SET',
+			command_report_parser: report => {
+				if (report.hasOwnProperty('Value')) return report['Value'] !== 0;
+				if (report.hasOwnProperty('Value (Raw)')) {
+					return report['Value (Raw)'][0] !== 0;
+				}
+				return null;
+			}
+			},
+		],
 		measure_battery: {
 			command_class: 'COMMAND_CLASS_BATTERY',
 			command_get: 'BATTERY_GET',
@@ -38,4 +52,5 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 			size: 4,
 		},
 	},
+	debug: false,
 });


### PR DESCRIPTION
This PR fixes support for DSB45 which uses BASIC_SET to send sensor reports. The current version only supports BINARY_SWITCH_REPORT, so I believe there are different software revisions.
The new addition has been tested and works perfectly.